### PR TITLE
Fixed first `'print' example

### DIFF
--- a/flipped_material/python/learning_briefs/0101_strings_variables_operations.md
+++ b/flipped_material/python/learning_briefs/0101_strings_variables_operations.md
@@ -19,7 +19,7 @@
 We can use the print function to print most data types to the standard console. 
 
 ```python
-print("hello world)
+print("hello world")
 ```
 
 ### Problem: we need to store something in a variable and then print it.


### PR DESCRIPTION
It was missing a quote on the right