### PR TITLE
correct `mdf` to `md5` in the example

### DIFF
--- a/learning/python/micro_lessons/hashing_and_encryption/hashlib/hashlib_cookbook.md
+++ b/learning/python/micro_lessons/hashing_and_encryption/hashlib/hashlib_cookbook.md
@@ -26,7 +26,7 @@ from haslib import md5
 
 def make_md5(phrase_to_hash):
   phrase_to_hash = phrase_to_hash.encode('utf-8')
-  m = mdf(phrase_to_hash)
+  m = md5(phrase_to_hash)
   return m.hexdigest()
 
 passphrase = "password"


### PR DESCRIPTION
The example used the `mdf` function instead of the `md5` function.

There is no such thing as the mdf function and running this code returns a NameError, with mdf not being defined. However, when mdf is changed to md5 the code works as intended